### PR TITLE
Cause traffic_server to die fast if a plugin is loaded that was not built with the correct core version.

### DIFF
--- a/build/plugins.mk
+++ b/build/plugins.mk
@@ -16,13 +16,21 @@
 
 # plugins.mk: Common automake build variables for Traffic Server plugins.
 
+GCC_VER_GET = $(CC) --version | tr ' ' '\\n' | grep --color=auto -F . | head -1
+CLANG_VER_GET = $(CC) -dumpversion
+# Assume clang if not gcc
+COMP_NAME := $(shell bash -c "if $(CC) --version | grep --color=auto -F gcc ; then echo gcc ; else echo clang ; fi")
+COMP_FULL_VER := $(shell bash -c "if $(CC) --version | grep --color=auto -F gcc ; then $(GCC_VER_GET) ; else $(CLANG_VER_GET) ; fi")
+COMP_MAJOR_VER := $(shell bash -c "echo $(COMP_FULL_VER) | tr '.' '\n' | head -1")
+COMP_MINOR_VER := $(shell bash -c "echo $(COMP_FULL_VER) | tr '.' '\n' | head -2 | tail -1")
+
 # Default plugin LDFLAGS. We don't use TS_PLUGIN_LDFLAGS because
 # that is an automake canonical variable name.
 TS_PLUGIN_LD_FLAGS = \
   -module \
   -shared \
   -avoid-version \
-  -export-symbols-regex '^(TSRemapInit|TSRemapDone|TSRemapDoRemap|TSRemapNewInstance|TSRemapDeleteInstance|TSRemapOSResponse|TSPluginInit)$$'
+  -export-symbols-regex '^(TSRemapInit|TSRemapDone|TSRemapDoRemap|TSRemapNewInstance|TSRemapDeleteInstance|TSRemapOSResponse|TSPluginInit_@TS_VERSION_MAJOR@)_$(COMP_NAME)_$(COMP_MAJOR_VER)_$(COMP_MINOR_VER)$$'
 
 TS_PLUGIN_CPPFLAGS = \
   -I$(abs_top_builddir)/proxy/api \

--- a/doc/developer-guide/api/functions/TSPluginInit.en.rst
+++ b/doc/developer-guide/api/functions/TSPluginInit.en.rst
@@ -44,6 +44,12 @@ calls this initialization routine when it loads the plugin and sets
 argument vector is the plugins name, which must exist in order for
 the plugin to be loaded.
 
+(Note that the identifier ``TSPluginInit`` is really a preprocessor symbol,
+defined by including ``<ts/ts.h>``,
+that translates to ``TSPluginInit_<M>``, where <M> is the Traffic Server major release number.
+This helps ensure that plugins are rebuilt before use with a new major release of Traffic
+Server.)
+
 :func:`TSPluginRegister` registers the appropriate SDK version specific in
 :arg:`sdk_version` for your plugin. Use this function to make sure that the
 version of Traffic Server on which your plugin is running supports the plugin.

--- a/include/ts/apidefs.h.in
+++ b/include/ts/apidefs.h.in
@@ -950,6 +950,28 @@ typedef struct TSSslSessionID_s {
    Init */
 
 /**
+    Cause TSPluginInit to have _<w>_<x>_<y>_<z> appended, when <w> is the major TS version nunber, <x> is compiler (gcc
+    or clang), <y> is major compiler release number, <z> is minor compiler release number.
+ */
+#define TSPluginInit TS_PLUGIN_INIT_(TS_VERSION_MAJOR, TS_COMPILER_USED, TS_COMPILER_MAJOR_RELEASE, TS_COMPILER_MINOR_RELEASE)
+
+/* PRIVATE -- do not use these diredtly *****/
+#if defined(__clang__)
+#define TS_COMPILER_USED clang
+#define TS_COMPILER_MAJOR_RELEASE __clang_major__
+#define TS_COMPILER_MINOR_RELEASE __clang_minor__
+#elif defined(__GNUC__)
+#define TS_COMPILER_USED gcc
+#define TS_COMPILER_MAJOR_RELEASE __GNUC__
+#define TS_COMPILER_MINOR_RELEASE __GNUC_MINOR__
+#else
+#error "must use gcc or clang"
+#endif
+#define TS_PLUGIN_INIT_(MAJOR, CNAME, CMAJOR, CMINOR) TS_PLUGIN_INIT__(MAJOR, CNAME, CMAJOR, CMINOR)
+#define TS_PLUGIN_INIT__(MAJOR, CNAME, CMAJOR, CMINOR) TSPluginInit_##MAJOR##_##CNAME##_##CMAJOR##_##CMINOR
+/********************************************/
+
+/**
     This function must be defined by all plugins. Traffic Server
     calls this initialization routine when it loads the plugin (at
     startup), and sets argc and argv appropriately based on the values

--- a/proxy/Plugin.cc
+++ b/proxy/Plugin.cc
@@ -112,13 +112,22 @@ plugin_load(int argc, char *argv[], bool validateOnly)
     plugin_reg_current->plugin_path = ats_strdup(path);
     plugin_reg_current->dlh         = handle;
 
-    init = (init_func_t)dlsym(plugin_reg_current->dlh, "TSPluginInit");
+#define X(P) Y(P)
+#define Y(P) #P
+
+    init = (init_func_t)dlsym(plugin_reg_current->dlh, X(TSPluginInit));
+
+#undef X
+#undef Y
+
     if (!init) {
       delete plugin_reg_current;
       if (validateOnly) {
         return false;
       }
-      Fatal("unable to find TSPluginInit function in '%s': %s", path, dlerror());
+      Fatal("unable to find TSPluginInit function in '%s': %s\n"
+            "make sure plugin was built with include files and libraries exported by major version %d of Traffic Server",
+            path, dlerror(), TS_VERSION_MAJOR);
       return false; // this line won't get called since Fatal brings down ATS
     }
 


### PR DESCRIPTION
And with same compiler version as core.